### PR TITLE
Use the updated API from v8 to define the plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sector-labs/postcss-inline-class",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Inline the declarations of other CSS classes in your CSS classes.",
   "main": "src/index.js",
   "repository": "https://github.com/sectorlabs/postcss-inline-class",
@@ -31,7 +31,7 @@
     "eslint-config-i-am-meticulous": "^12.0.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-prettier": "^3.1.2",
-    "postcss-tape": "^5.0.2",
+    "postcss-tape": "^6.0.0",
     "prettier": "^2.0.4"
   },
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,14 @@ const defaultOptions = Object.freeze({
     extensions: [''],
 });
 
-module.exports = postcss.plugin('postcss-inline-class', (options) => {
-    return (root, result) =>
-        new Promise(processFile(root, result, (options || defaultOptions).paths));
-});
+const plugin = (options) => {
+    return {
+        postcssPlugin: 'postcss-inline-class',
+        Once(root, { result }) {
+            return new Promise(processFile(root, result, (options || defaultOptions).paths));
+        },
+    };
+};
+plugin.postcss = true;
+
+module.exports = plugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,10 +1229,10 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
   integrity sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==
 
-postcss-tape@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-tape/-/postcss-tape-5.0.2.tgz#7ae011050954fdc10b17d1f1551c9d9bf14e4bdf"
-  integrity sha512-e4770WnsUzczQp/pAIsz0s0MDLAQ7luyh1/hs8QBcdfXOMrz0siEqYNHAKJIoCvGtLoi2QUjWASvTbPfyTfIWg==
+postcss-tape@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-tape/-/postcss-tape-6.0.1.tgz#c81bd77c79c7a9a9a559b6af04a02e4487eb467a"
+  integrity sha512-qw/1YCSoGgmz8DC/8lbUo3OZGN0UWWZdThAvCSOIJrK346Weu8bM+aC5c9q1/Np2YjCJfRqhJO+P94A3sLdWhQ==
 
 postcss@^8.0.0:
   version "8.4.47"


### PR DESCRIPTION
https://evilmartians.com/chronicles/postcss-8-plugin-migration This removes the warning "postcss-inline-class: postcss.plugin was deprecated"

postcss-tape was update because the previous version was not compatible with post css v8 syntax: https://github.com/csstools/postcss-tape/issues/5